### PR TITLE
Remove missing rails path

### DIFF
--- a/lib/superglue.rb
+++ b/lib/superglue.rb
@@ -23,12 +23,6 @@ module Superglue
     config.superglue = ActiveSupport::OrderedOptions.new
     config.superglue.auto_include = true
 
-    generators do |app|
-      Rails::Generators.configure! app.config.generators
-      Rails::Generators.hidden_namespaces.uniq!
-      require "generators/rails/scaffold_controller_generator"
-    end
-
     initializer :superglue do |app|
       ActiveSupport.on_load(:action_controller) do
         next if self != ActionController::Base


### PR DESCRIPTION
Rails already picks up the correct generators, in some cases, CI passes but in some cases bootsnap fails to load this.