### PR TITLE
Fix depth security issue

### DIFF
--- a/lib/superglue/helpers.rb
+++ b/lib/superglue/helpers.rb
@@ -29,7 +29,6 @@ module Superglue
           .squeeze(".")
           .split(".")
 
-        # Raise error if depth exceeds security limit
         if path_array.length > MAX_DIG_DEPTH
           raise DigPathTooDeepError.new(path_array.length, MAX_DIG_DEPTH)
         end

--- a/lib/superglue/helpers.rb
+++ b/lib/superglue/helpers.rb
@@ -1,5 +1,13 @@
 module Superglue
   module Helpers
+    class DigPathTooDeepError < StandardError
+      def initialize(depth, max_depth)
+        super("Parameter dig path too deep: #{depth} levels (maximum allowed: #{max_depth})")
+      end
+    end
+
+    MAX_DIG_DEPTH = 50
+
     def redirect_back_with_props_at(opts)
       if request.referrer && params[:props_at]
         referrer_url = URI.parse(request.referrer)
@@ -16,10 +24,17 @@ module Superglue
 
     def param_to_dig_path(param)
       if param
-        param
+        path_array = param
           .gsub(/[^\da-zA-Z_=.]+/, "")
           .squeeze(".")
           .split(".")
+
+        # Raise error if depth exceeds security limit
+        if path_array.length > MAX_DIG_DEPTH
+          raise DigPathTooDeepError.new(path_array.length, MAX_DIG_DEPTH)
+        end
+
+        path_array
       end
     end
   end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -16,7 +16,6 @@ class HelpersTest < ActiveSupport::TestCase
   end
 
   test "raises error when depth exceeds limit" do
-    # Create a string with 51 levels (1 over the 50 limit)
     deep_path = (1..51).map(&:to_s).join(".")
     
     error = assert_raises(Superglue::Helpers::DigPathTooDeepError) do
@@ -28,7 +27,6 @@ class HelpersTest < ActiveSupport::TestCase
   end
   
   test "allows paths at the depth limit" do
-    # Create a string with exactly 50 levels
     exact_limit_path = (1..50).map(&:to_s).join(".")
     result = param_to_dig_path(exact_limit_path)
     

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -14,4 +14,33 @@ class HelpersTest < ActiveSupport::TestCase
 
     assert_equal param_to_dig_path(qry), ["foo", "bar"]
   end
+
+  test "raises error when depth exceeds limit" do
+    # Create a string with 51 levels (1 over the 50 limit)
+    deep_path = (1..51).map(&:to_s).join(".")
+    
+    error = assert_raises(Superglue::Helpers::DigPathTooDeepError) do
+      param_to_dig_path(deep_path)
+    end
+    
+    assert_match(/Parameter dig path too deep: 51 levels/, error.message)
+    assert_match(/maximum allowed: 50/, error.message)
+  end
+  
+  test "allows paths at the depth limit" do
+    # Create a string with exactly 50 levels
+    exact_limit_path = (1..50).map(&:to_s).join(".")
+    result = param_to_dig_path(exact_limit_path)
+    
+    assert_equal 50, result.length
+    assert_equal (1..50).map(&:to_s), result
+  end
+  
+  test "allows normal depth paths" do
+    normal_path = "users.0.posts.2.title"
+    result = param_to_dig_path(normal_path)
+    
+    assert_equal ["users", "0", "posts", "2", "title"], result
+    assert_equal 5, result.length
+  end
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -281,3 +281,15 @@ class RenderTest < ActionController::TestCase
     }
   end
 end
+
+class SecurityTest < ActionController::TestCase
+  tests RenderController
+
+  test "deep props_at parameter raises security error when processed" do
+    deep_props_at = (1..60).map(&:to_s).join(".")
+
+    assert_raises(Superglue::Helpers::DigPathTooDeepError) do
+      @controller.param_to_dig_path(deep_props_at)
+    end
+  end
+end


### PR DESCRIPTION
fix(security): prevent DoS attacks via deep parameter nesting

Add depth limit of 50 levels to param_to_dig_path method to prevent attackers from causing server hangs through extremely long nested parameter strings.

- Add DigPathTooDeepError for security violations
- Add MAX_DIG_DEPTH constant set to 50 levels
- Throw descriptive error when depth limit exceeded
- Add comprehensive security tests covering edge cases
- Add integration test for controller context

The 50-level limit is generous for normal usage (typically 3-7 levels) while preventing resource exhaustion attacks.