### PR TITLE
Add support for stream response

### DIFF
--- a/app/helpers/superglue/streams_helper.rb
+++ b/app/helpers/superglue/streams_helper.rb
@@ -16,4 +16,51 @@ module Superglue::StreamsHelper
       value.to_s
     end
   end
+
+  def broadcast_prepend_props(model: nil, fragment: nil, save_as: nil, options: {}, **rendering)
+    if save_as
+      options[:saveAs] ||= fragment_id(save_as)
+    end
+
+    broadcast_action_props(action: "prepend", model:, fragment:, options:, **rendering)
+  end
+
+  def broadcast_append_props(model: nil, fragment: nil, save_as: nil, options: {}, **rendering)
+    if save_as
+      options[:saveAs] ||= fragment_id(save_as)
+    end
+
+    broadcast_action_props(action: "append", model:, fragment:, options:, **rendering)
+  end
+
+  def broadcast_save_props(model: nil, partial: nil, fragment: nil, options: {}, **rendering)
+    broadcast_action_props(action: "save", model:, fragment:, options:, **rendering)
+  end
+
+  def broadcast_action_props(action:, partial: nil, model: nil, fragment: nil, options: {}, **rendering)
+    if model
+      fragment = model.broadcast_fragment_default if !fragment
+
+      if model.respond_to?(:to_partial_path)
+        rendering[:locals] = (rendering[:locals] || {}).reverse_merge(model.model_name.element.to_sym => model).compact
+        partial ||= model.to_partial_path
+      end
+    end
+
+    fragment = fragment_id(fragment)
+
+    if !partial
+      raise StandardError, "A partial is needed to render a stream"
+    end
+
+    json = instance_variable_get(:@__json)
+
+    json.child! do
+      json.fragmentKeys [fragment]
+      json.action action
+      json.options(options)
+      json.data(partial: [partial, rendering]) do
+      end
+    end
+  end
 end

--- a/lib/generators/superglue/install/install_generator.rb
+++ b/lib/generators/superglue/install/install_generator.rb
@@ -30,6 +30,9 @@ module Superglue
         say "Copying application.json.props"
         copy_file "#{__dir__}/templates/application.json.props", "app/views/layouts/application.json.props"
 
+        say "Copying stream.json.props"
+        copy_file "#{__dir__}/templates/stream.json.props", "app/views/layouts/stream.json.props"
+
         say "Adding required member methods to ApplicationRecord"
         add_member_methods
 

--- a/lib/generators/superglue/install/templates/stream.json.props
+++ b/lib/generators/superglue/install/templates/stream.json.props
@@ -1,0 +1,15 @@
+json.disable_deferments!
+
+json.data do
+  json.array! do
+    yield json
+  end
+end
+json.fragments json.fragments!
+json.assets [ asset_path('application.js') ]
+
+if protect_against_forgery?
+  json.csrfToken form_authenticity_token
+end
+
+json.action "stream"

--- a/test/dummy/app/views/layouts/stream.json.props
+++ b/test/dummy/app/views/layouts/stream.json.props
@@ -1,0 +1,15 @@
+json.disable_deferments!
+
+json.data do
+  json.array! do
+    yield json
+  end
+end
+# json.fragments json.fragments!
+# json.assets [ asset_path('application.js') ]
+
+# if protect_against_forgery?
+#   json.csrfToken form_authenticity_token
+# end
+
+# json.action "stream"

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -130,3 +130,301 @@ class StreamsHelperTest < ActiveSupport::TestCase
     assert result[:signed_stream_name].present?
   end
 end
+
+class BroadcastViewHelpersTest < ActiveSupport::TestCase
+  include ActionViewTestCaseExtensions
+  include Superglue::StreamsHelper
+
+  setup do
+    @message = Message.new(id: 1, content: "Hello!")
+    controller = ApplicationController.new
+    controller.request = ActionDispatch::TestRequest.create
+    controller.response = ActionDispatch::TestResponse.new
+    controller.prepend_view_path "test/views"
+    @controller = controller
+  end
+
+  def with_json_template(template_content)
+    template_dir = File.expand_path("../views/application", __FILE__)
+    template_path = File.join(template_dir, "test_broadcast.json.props")
+    File.delete(template_path) if File.exist?(template_path)
+    File.write(template_path, template_content)
+
+    @controller.view_paths.each(&:clear_cache)
+
+    yield
+  ensure
+    File.delete(template_path) if File.exist?(template_path)
+  end
+
+  test "broadcast_prepend_props with model generates expected JSON structure" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_prepend_props(model: @message)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      message = Message.new(id: 1, content: "Hello!")
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message:}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "prepend",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_prepend_props with save_as option" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_prepend_props(model: @message, save_as: "custom_fragment")
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "prepend",
+        options: {saveAs: "custom_fragment"},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_append_props with model generates expected JSON structure" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_append_props(model: @message)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "append",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_append_props with save_as option using model" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_append_props(model: @message, save_as: @message)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "append",
+        options: {saveAs: "message_1"},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_save_props with model" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_save_props(model: @message)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "save",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props with custom action and fragment" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "replace", model: @message, fragment: "custom_frag")
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["custom_frag"],
+        action: "replace",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props with partial and no model" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "update", partial: "messages/message", fragment: "msg_123", locals: {message: @message})
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["msg_123"],
+        action: "update",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props raises error when no partial can be determined" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "save", fragment: "some_fragment")
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      assert_raises ActionView::Template::Error, "A partial is needed to render a stream" do
+        @controller.render_to_string("test_broadcast", format: :json, layout: false)
+      end
+    end
+  end
+
+  test "broadcast methods pass through custom options" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_prepend_props(model: @message, options: {target: "#messages", position: "afterbegin"})
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "prepend",
+        options: {target: "#messages", position: "afterbegin"},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast methods with custom rendering options" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_append_props(model: @message, locals: {custom_var: "custom_value"})
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["messages"],
+        action: "append",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props uses model.broadcast_fragment_default when no fragment provided" do
+    custom_model = Message.new(id: 1, content: "Custom")
+    def custom_model.broadcast_fragment_default
+      "custom_messages"
+    end
+
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "prepend", model: @custom_model)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {custom_model:}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["custom_messages"],
+        action: "prepend",
+        options: {},
+        data: {
+          body: "Custom"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props explicit fragment overrides broadcast_fragment_default" do
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "append", model: @message, fragment: "explicit_fragment")
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      result = @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {message: @message}).chomp
+
+      assert_equal(result, [{
+        fragmentKeys: ["explicit_fragment"],
+        action: "append",
+        options: {},
+        data: {
+          body: "Hello!"
+        }
+      }].to_json)
+    end
+  end
+
+  test "broadcast_action_props handles model without broadcast_fragment_default method" do
+    # Create a plain object that doesn't have broadcast_fragment_default
+    plain_model = OpenStruct.new(id: 1, content: "Plain", model_name: OpenStruct.new(element: "plain"))
+    def plain_model.to_partial_path
+      "messages/message"
+    end
+
+    template_content = <<~PROPS
+      json.array! do
+        broadcast_action_props(action: "save", model: @plain_model)
+      end
+    PROPS
+
+    with_json_template(template_content) do
+      assert_raises NoMethodError do
+        @controller.render_to_string("test_broadcast", format: :json, layout: false, assigns: {plain_model:})
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is equivalent to Turbostream's stream responses. Here's create example:

Turbostreams:

```
  def create
    message = Message.create!(params.require(:message).permit(:content))

    respond_to do |format|
      format.turbo_stream {render locals: {message: message} }
      # For browsers without JS
      format.html { redirect_to messages_url }
    end
  end
```
and in `create.turbo_stream.erb`

```
<%= turbo_stream.prepend "messages", @message%>
```

in Superglue this would be

```
  def create
    message = Message.create!(params.require(:message).permit(:content))

    respond_to do |format|
      format.json { render layout: 'stream', locals: {message: message}}
      # For browsers without JS
      format.html { redirect_to messages_url }
    end
  end
```

and in `create.json.props`

```
  broadcast_prepend_props(model: @message, fragment: 'messages')
```

Notice that we have to use a `stream` layout, that will be included in every generated install of superglue_rails.